### PR TITLE
Fix mobile sidebar visibility guard

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -55,12 +55,6 @@
      * needs to stay important so the later desktop `.book-sidebar` z-index in
      * main.css cannot drop the mobile drawer behind the overlay.
      */
-    z-index: 999 !important;
-    transform: translateX(-100%) !important;
-    visibility: hidden;
-    transition:
-      transform 0.3s ease,
-      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -68,6 +62,12 @@
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -56,6 +56,11 @@
      * main.css cannot drop the mobile drawer behind the overlay.
      */
     z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -63,13 +68,13 @@
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
-    transform: translateX(-100%) !important;
-    transition: transform 0.3s ease;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */


### PR DESCRIPTION
## Summary
- Reinforce the mobile/tablet sidebar closed state with `visibility: hidden` and a delayed visibility transition.
- Keep the opened sidebar visible and above the overlay while preserving the existing off-canvas transform fix.
- This repository has a single tracked `mobile-responsive.css`, so the guard is applied only to that stylesheet.

Part of itdojp/it-engineer-knowledge-architecture#168.

## Verification
- `git diff --check`
- Static CSS guard check for `z-index: 999 !important`, closed `transform: translateX(-100%) !important`, closed `visibility: hidden`, delayed visibility transition, and opened `visibility: visible`.
